### PR TITLE
[exporter/datadog] Add logs to investigate i/o timeouts against the t…

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,14 +1,14 @@
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 
-RUN mkdir -p /tmp
-
-FROM scratch
-
-ARG USER_UID=10001
-USER ${USER_UID}
-
-COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# RUN mkdir -p /tmp
+#
+# FROM scratch
+#
+# ARG USER_UID=10001
+# USER ${USER_UID}
+#
+# COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /
 EXPOSE 4317 55680 55679
 ENTRYPOINT ["/otelcontribcol"]


### PR DESCRIPTION
…race endpoint

This PRs:
- add a log containing more information about payload that fail to be posted to datadog, in particular regarding limits exhibited here: https://docs.datadoghq.com/tracing/troubleshooting/
- base the target container off Alpine to that we can exec into it and inspect the /etc/otel/config.yaml file